### PR TITLE
Add docker files for easier development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ To install the plugin, run the following command, changing the version in URL to
 bin/elasticsearch-plugin install https://github.com/EvidentSolutions/elasticsearch-analysis-raudikko/releases/download/v0.1.1/elasticsearch-analysis-raudikko-0.1.1-es7.16.3.zip
 ```
 
+### Docker
+Building the plugin and running with docker
+```
+./gradlew build --DelastisearchVersion=8.5.3
+cd etc
+docker compose build --build-arg "ES_VERSION=8.5.3"
+docker compose up
+```
+Elasticsearch should be running and available at port 9200
+
 ### Verify installation
 
 After installing the plugin, you can quickly verify that it works by executing:

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,0 +1,8 @@
+ARG ES_VERSION=8.5.3
+FROM elasticsearch:${ES_VERSION}
+# Needs to repeat the ARG here or it won't work
+# https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG ES_VERSION
+COPY /build/distributions/elasticsearch-analysis-raudikko-0.1-es${ES_VERSION}.zip /install/elasticsearch-analysis-raudikko.zip
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install \
+    --batch file:///install/elasticsearch-analysis-raudikko.zip \

--- a/etc/docker-compose.yml
+++ b/etc/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+services:
+  elasticsearch:
+    build:
+      dockerfile: /etc/Dockerfile
+      context: ../
+      # change version here or use
+      # docker compose build --build-arg "ES_VERSION=<custom_version>"
+      #args:
+        #ES_VERSION: 8.5.3
+    ports:
+      - "9200:9200"
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+      - xpack.security.enabled=false
+    # NOTE on WSL needed to adjust following
+    # wsl -d docker-desktop
+    # sysctl -w vm.max_map_count=262144

--- a/etc/test-analyzer.http
+++ b/etc/test-analyzer.http
@@ -4,7 +4,7 @@ Content-Type: application/json; charset=UTF-8
 
 {
   "tokenizer" : "finnish",
-  "filter" : ["raudikko"],
+  "filter" : [{"type": "raudikko"}],
   "text" : "Testataan raudikon analyysiä tällä tavalla yksinkertaisesti."
 }
 

--- a/etc/test-analyzer.http
+++ b/etc/test-analyzer.http
@@ -1,3 +1,4 @@
+### test analyzer
 GET localhost:9200/_analyze
 Content-Type: application/json; charset=UTF-8
 
@@ -6,3 +7,12 @@ Content-Type: application/json; charset=UTF-8
   "filter" : ["raudikko"],
   "text" : "Testataan raudikon analyysiä tällä tavalla yksinkertaisesti."
 }
+
+### check status
+GET http://localhost:9200/_cluster/health?pretty
+
+### check version
+GET http://localhost:9200
+
+### show plugins
+GET http://localhost:9200/_cat/plugins?v=true&s=component&h=component,version,description


### PR DESCRIPTION
Helps to whip up elasticsearch with freshly built raudikko plugin.

Maybe even better would be to run some integration tests in the build w/ e.g. https://www.testcontainers.org/modules/docker_compose/ but this helped me do manual testing with ES8 support.